### PR TITLE
EXPERIMENTAL: map/list interfaces

### DIFF
--- a/datamodel/container.go
+++ b/datamodel/container.go
@@ -1,0 +1,8 @@
+package datamodel
+
+type Container interface {
+	Empty() bool
+	Length() int64
+	Clear()
+	Values() []Node
+}

--- a/datamodel/list.go
+++ b/datamodel/list.go
@@ -1,0 +1,11 @@
+package datamodel
+
+type List interface {
+	Get(idx int64) (Node, bool)
+	Remove(idx int64)
+	Append(values ...interface{})
+	Insert(idx int64, values ...interface{})
+	Set(idx int64, value interface{})
+
+	Container
+}

--- a/datamodel/map.go
+++ b/datamodel/map.go
@@ -1,0 +1,10 @@
+package datamodel
+
+type Map interface {
+	Put(key string, value interface{}) bool
+	Get(key string) (value Node, found bool)
+	Remove(key string) bool
+	Keys() []string
+
+	Container
+}

--- a/traversal/amendAny.go
+++ b/traversal/amendAny.go
@@ -92,10 +92,10 @@ func (a *anyAmender) Prototype() datamodel.NodePrototype {
 
 // -- Amender -->
 
-func (a *anyAmender) Get(prog *Progress, path datamodel.Path, trackProgress bool) (datamodel.Node, error) {
+func (a *anyAmender) Fetch(prog *Progress, path datamodel.Path, trackProgress bool) (datamodel.Node, error) {
 	// If the base node is an amender, use it, otherwise return the base node.
 	if amd, castOk := a.base.(Amender); castOk {
-		return amd.Get(prog, path, trackProgress)
+		return amd.Fetch(prog, path, trackProgress)
 	}
 	return a.base, nil
 }

--- a/traversal/amendLink.go
+++ b/traversal/amendLink.go
@@ -118,7 +118,7 @@ func (a *linkAmender) Prototype() datamodel.NodePrototype {
 
 // -- Amender -->
 
-func (a *linkAmender) Get(prog *Progress, path datamodel.Path, trackProgress bool) (datamodel.Node, error) {
+func (a *linkAmender) Fetch(prog *Progress, path datamodel.Path, trackProgress bool) (datamodel.Node, error) {
 	// Check the budget
 	if prog.Budget != nil {
 		if prog.Budget.LinkBudget <= 0 {
@@ -133,7 +133,7 @@ func (a *linkAmender) Get(prog *Progress, path datamodel.Path, trackProgress boo
 	if path.Len() == 0 {
 		return a.Build(), nil
 	}
-	return a.child.Get(prog, path, trackProgress)
+	return a.child.Fetch(prog, path, trackProgress)
 }
 
 func (a *linkAmender) Transform(prog *Progress, path datamodel.Path, fn TransformFn, createParents bool) (datamodel.Node, error) {

--- a/traversal/amendList.go
+++ b/traversal/amendList.go
@@ -11,6 +11,7 @@ import (
 
 var (
 	_ datamodel.Node = &listAmender{}
+	_ datamodel.List = &listAmender{}
 	_ Amender        = &listAmender{}
 )
 
@@ -160,7 +161,7 @@ func (itr *listAmender_Iterator) Done() bool {
 
 // -- Amender -->
 
-func (a *listAmender) Get(prog *Progress, path datamodel.Path, trackProgress bool) (datamodel.Node, error) {
+func (a *listAmender) Fetch(prog *Progress, path datamodel.Path, trackProgress bool) (datamodel.Node, error) {
 	// If the root is requested, return the `Node` view of the amender.
 	if path.Len() == 0 {
 		return a.Build(), nil
@@ -188,7 +189,7 @@ func (a *listAmender) Get(prog *Progress, path datamodel.Path, trackProgress boo
 	if err != nil {
 		return nil, err
 	}
-	return childAmender.Get(prog, remainingPath, trackProgress)
+	return childAmender.Fetch(prog, remainingPath, trackProgress)
 }
 
 func (a *listAmender) Transform(prog *Progress, path datamodel.Path, fn TransformFn, createParents bool) (datamodel.Node, error) {
@@ -342,4 +343,51 @@ func (a *listAmender) storeChildAmender(childIdx int64, n datamodel.Node, k data
 		return childAmender, nil
 	}
 	return a.opts.newAmender(n, a, k, create), nil
+}
+
+// -- List -->
+
+func NewList(base interface{}) datamodel.List {
+	// TODO: `base` must be of "list" type
+	return AmendOptions{}.newListAmender(nodeForType(base), nil, false).(*listAmender)
+}
+
+func (a *listAmender) Get(idx int64) (datamodel.Node, bool) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (a *listAmender) Remove(idx int64) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (a *listAmender) Append(values ...interface{}) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (a *listAmender) Insert(idx int64, values ...interface{}) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (a *listAmender) Set(idx int64, value interface{}) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (a *listAmender) Empty() bool {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (a *listAmender) Clear() {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (a *listAmender) Values() []datamodel.Node {
+	//TODO implement me
+	panic("implement me")
 }

--- a/traversal/amendUtils.go
+++ b/traversal/amendUtils.go
@@ -1,0 +1,71 @@
+package traversal
+
+import (
+	"log"
+
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/node/basicnode"
+)
+
+func nodeForType(base interface{}) datamodel.Node {
+	if base == nil {
+		return nil
+	}
+	switch typ := base.(type) {
+	case Amender:
+		return base.(Amender).Build()
+	case datamodel.Node:
+		return base.(datamodel.Node)
+	case datamodel.Link:
+		return basicnode.NewLink(base.(datamodel.Link))
+	case bool:
+		return basicnode.NewBool(base.(bool))
+	case int8:
+		return basicnode.NewInt(int64(base.(int8)))
+	case int16:
+		return basicnode.NewInt(int64(base.(int16)))
+	case int32:
+		return basicnode.NewInt(int64(base.(int32)))
+	case int64:
+		return basicnode.NewInt(base.(int64))
+	case int:
+		return basicnode.NewInt(int64(base.(int)))
+	case uint8:
+		return basicnode.NewUint(uint64(base.(uint8)))
+	case uint16:
+		return basicnode.NewUint(uint64(base.(uint16)))
+	case uint32:
+		return basicnode.NewUint(uint64(base.(uint32)))
+	case uint64:
+		return basicnode.NewUint(base.(uint64))
+	case uint:
+		return basicnode.NewUint(uint64(base.(uint)))
+	case float32:
+		return basicnode.NewFloat(float64(base.(float32)))
+	case float64:
+		return basicnode.NewFloat(base.(float64))
+	case string:
+		return basicnode.NewString(base.(string))
+	case []byte: // Special handling for array of bytes
+		{
+			return basicnode.NewBytes(base.([]byte))
+		}
+	case map[string]interface{}:
+		{
+			a := AmendOptions{}.newMapAmender(nil, nil, false)
+			for k, v := range base.(map[string]interface{}) {
+				a.(datamodel.Map).Put(k, v)
+			}
+			return a.Build()
+		}
+	case []interface{}:
+		{
+			a := AmendOptions{}.newListAmender(nil, nil, false)
+			a.(datamodel.List).Append(base.([]interface{}))
+			return a.Build()
+		}
+	default:
+		log.Printf("invalid type: %s", typ)
+		panic("unreachable")
+	}
+}

--- a/traversal/amender.go
+++ b/traversal/amender.go
@@ -3,9 +3,9 @@ package traversal
 import "github.com/ipld/go-ipld-prime/datamodel"
 
 type Amender interface {
-	// Get returns the node at the specified path. It will not create any intermediate nodes because this is just a
+	// Fetch returns the node at the specified path. It will not create any intermediate nodes because this is just a
 	// retrieval and not a modification operation.
-	Get(prog *Progress, path datamodel.Path, trackProgress bool) (datamodel.Node, error)
+	Fetch(prog *Progress, path datamodel.Path, trackProgress bool) (datamodel.Node, error)
 
 	// Transform will do an in-place transformation of the node at the specified path and return its previous value.
 	// If `createParents = true`, any missing parents will be created, otherwise this function will return an error.

--- a/traversal/focus.go
+++ b/traversal/focus.go
@@ -79,7 +79,7 @@ func (prog Progress) Get(n datamodel.Node, p datamodel.Path) (datamodel.Node, er
 // For Get calls, trackProgress=false, which avoids some allocations for state tracking that's not needed by that call.
 func (prog *Progress) get(n datamodel.Node, p datamodel.Path, trackProgress bool) (datamodel.Node, error) {
 	prog.init()
-	return NewAmender(n).Get(prog, p, trackProgress)
+	return NewAmender(n).Fetch(prog, p, trackProgress)
 }
 
 // FocusedTransform traverses a datamodel.Node graph, reaches a single Node,

--- a/traversal/map_test.go
+++ b/traversal/map_test.go
@@ -1,0 +1,75 @@
+package traversal_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/fluent/qp"
+	"github.com/ipld/go-ipld-prime/node/basicnode"
+	nodetests "github.com/ipld/go-ipld-prime/node/tests"
+	"github.com/ipld/go-ipld-prime/traversal"
+)
+
+func TestMapUpdate(t *testing.T) {
+	nestedMapNode, _ := qp.BuildMap(basicnode.Prototype.Map, 3, func(ma datamodel.MapAssembler) {
+		qp.MapEntry(ma, "alink", qp.Link(leafAlphaLnk))
+		qp.MapEntry(ma, "nonlink", qp.String("zoo"))
+	})
+	t.Run("read map", func(t *testing.T) {
+		m := traversal.NewMap(middleMapNode)
+		foo, foundFoo := m.Get("foo")
+		qt.Check(t, foundFoo, qt.IsTrue)
+		qt.Check(t, foo, nodetests.NodeContentEquals, basicnode.NewBool(true))
+		bar, foundBar := m.Get("bar")
+		qt.Check(t, foundBar, qt.IsTrue)
+		qt.Check(t, bar, nodetests.NodeContentEquals, basicnode.NewBool(false))
+		nested, foundNested := m.Get("nested")
+		qt.Check(t, foundNested, qt.IsTrue)
+		qt.Check(t, nested, nodetests.NodeContentEquals, nestedMapNode)
+	})
+	t.Run("new map", func(t *testing.T) {
+		m1 := traversal.NewMap(nil)
+		putFoo := m1.Put("foo", true)
+		qt.Check(t, putFoo, qt.IsTrue)
+		putBar := m1.Put("bar", false)
+		qt.Check(t, putBar, qt.IsTrue)
+		m2 := traversal.NewMap(nil)
+		putLink := m2.Put("alink", leafAlphaLnk)
+		qt.Check(t, putLink, qt.IsTrue)
+		putNonlink := m2.Put("nonlink", "zoo")
+		qt.Check(t, putNonlink, qt.IsTrue)
+		qt.Check(t, m2.(datamodel.Node), nodetests.NodeContentEquals, nestedMapNode)
+		putNested := m1.Put("nested", m2)
+		qt.Check(t, putNested, qt.IsTrue)
+		qt.Check(t, m1.(datamodel.Node), nodetests.NodeContentEquals, middleMapNode)
+	})
+	t.Run("update map", func(t *testing.T) {
+		m := traversal.NewMap(map[string]interface{}{
+			"foo": true,
+			"bar": false,
+		})
+		// Check values
+		foo, foundFoo := m.Get("foo")
+		qt.Check(t, foundFoo, qt.IsTrue)
+		qt.Check(t, foo, nodetests.NodeContentEquals, basicnode.NewBool(true))
+		bar, foundBar := m.Get("bar")
+		qt.Check(t, foundBar, qt.IsTrue)
+		qt.Check(t, bar, nodetests.NodeContentEquals, basicnode.NewBool(false))
+
+		// Flip values
+		putFoo := m.Put("foo", false)
+		qt.Check(t, putFoo, qt.IsTrue)
+		putBar := m.Put("bar", true)
+		qt.Check(t, putBar, qt.IsTrue)
+
+		// Check flipped values
+		foo, foundFoo = m.Get("foo")
+		qt.Check(t, foundFoo, qt.IsTrue)
+		qt.Check(t, foo, nodetests.NodeContentEquals, basicnode.NewBool(false))
+		bar, foundBar = m.Get("bar")
+		qt.Check(t, foundBar, qt.IsTrue)
+		qt.Check(t, bar, nodetests.NodeContentEquals, basicnode.NewBool(true))
+	})
+}

--- a/traversal/patch/eval.go
+++ b/traversal/patch/eval.go
@@ -104,7 +104,7 @@ func evalOne(prog *traversal.Progress, n datamodel.Node, op Operation) (datamode
 			return nil, err
 		}
 	case Op_Copy:
-		if source, err := a.Get(prog, op.From, true); err != nil {
+		if source, err := a.Fetch(prog, op.From, true); err != nil {
 			return nil, err
 		} else if _, err := a.Transform(prog, op.Path, func(progress traversal.Progress, node datamodel.Node) (datamodel.Node, error) {
 			return source, nil
@@ -112,7 +112,7 @@ func evalOne(prog *traversal.Progress, n datamodel.Node, op Operation) (datamode
 			return nil, err
 		}
 	case Op_Test:
-		if point, err := a.Get(prog, op.Path, true); err != nil {
+		if point, err := a.Fetch(prog, op.Path, true); err != nil {
 			return nil, err
 		} else if !datamodel.DeepEqual(point, op.Value) {
 			return nil, fmt.Errorf("test failed") // TODO real error handling and a code


### PR DESCRIPTION
Very experimental changes for (hopefully) more usable `map` and `list` interfaces for IPLD nodes, based on [amend](https://github.com/ipld/go-ipld-prime/pull/445).

I wanted to get some early feedback so only the `map` interface is implemented. The tests in `map_test.go` demonstrate some ways in which the interface can be used.

cc @RangerMauve @rvagg @aschmahmann @BigLep @warpfork
```
type Map interface {
	Put(key string, value interface{}) bool
	Get(key string) (value Node, found bool)
	Remove(key string) bool
	Keys() []string

	Container
}
```
```
type List interface {
	Get(idx int64) (Node, bool)
	Remove(idx int64)
	Append(values ...interface{})
	Insert(idx int64, values ...interface{})
	Set(idx int64, value interface{})

	Container
}
```
```
type Container interface {
	Empty() bool
	Length() int64
	Clear()
	Values() []Node
}
```